### PR TITLE
Allow checking permissions of Entities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version=2.4.1
+mod_version=2.5.0
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomLib
 archives_base_name=blossom-lib

--- a/src/main/java/dev/codedsakura/blossom/lib/BlossomLib.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/BlossomLib.java
@@ -93,7 +93,7 @@ public class BlossomLib implements ModInitializer {
                                         return 1;
                                     })))
                     .then(literal("clear-cooldowns")
-                            .requires(Permissions.require("bolssom.lib.base-command.clear.cooldowns", 2))
+                            .requires(Permissions.require("blossom.lib.base-command.clear.cooldowns", 2))
                             .executes(ctx -> {
                                 TeleportUtils.cancelAllCooldowns();
                                 TextUtils.sendOps(ctx, "blossom.clear-cooldowns.all");

--- a/src/main/java/dev/codedsakura/blossom/lib/permissions/Permissions.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/permissions/Permissions.java
@@ -62,4 +62,14 @@ public class Permissions {
         }
         return source.hasPermissionLevel(level);
     }
+
+    /**
+     * @see me.lucko.fabric.api.permissions.v0.Permissions#check(Entity, String, boolean)
+     */
+    public static boolean check(@NotNull Entity entity, @NotNull String permission, boolean fallback) {
+        if (isFPAPILoaded()) {
+            return PermissionsExecutor.check(entity, permission, fallback);
+        }
+        return fallback;
+    }
 }

--- a/src/main/java/dev/codedsakura/blossom/lib/permissions/Permissions.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/permissions/Permissions.java
@@ -72,4 +72,14 @@ public class Permissions {
         }
         return fallback;
     }
+
+    /**
+     * @see me.lucko.fabric.api.permissions.v0.Permissions#check(Entity, String, int)
+     */
+    public static boolean check(@NotNull Entity entity, @NotNull String permission, int level) {
+        if (isFPAPILoaded()) {
+            return PermissionsExecutor.check(entity, permission, level);
+        }
+        return entity.hasPermissionLevel(level);
+    }
 }

--- a/src/main/java/dev/codedsakura/blossom/lib/permissions/PermissionsExecutor.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/permissions/PermissionsExecutor.java
@@ -1,6 +1,7 @@
 package dev.codedsakura.blossom.lib.permissions;
 
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.entity.Entity;
 import net.minecraft.server.command.ServerCommandSource;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,5 +22,9 @@ class PermissionsExecutor {
 
     static boolean check(@NotNull ServerCommandSource source, @NotNull String permission, int level) {
         return Permissions.check(source, permission, level);
+    }
+
+    static boolean check(@NotNull Entity entity, @NotNull String permission, boolean fallback) {
+        return Permissions.check(entity, permission, fallback);
     }
 }

--- a/src/main/java/dev/codedsakura/blossom/lib/permissions/PermissionsExecutor.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/permissions/PermissionsExecutor.java
@@ -27,4 +27,8 @@ class PermissionsExecutor {
     static boolean check(@NotNull Entity entity, @NotNull String permission, boolean fallback) {
         return Permissions.check(entity, permission, fallback);
     }
+
+    static boolean check(@NotNull Entity entity, @NotNull String permission, int level) {
+        return Permissions.check(entity, permission, level);
+    }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "blossom-lib.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.13.3",
+    "fabricloader": ">=0.14.7",
     "fabric": "*",
     "minecraft": "1.19.x"
   },


### PR DESCRIPTION
As opposed to a `ServerPlayerEntity` derived from `ServerCommandSource`.
(there may be a more efficient way to do this)