### PR TITLE
1.21.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.15
+
+* Update to support 1.21.7
+
 # 2.5.14
 
 * Update to support 1.21.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.5.15
 
-* Update to support 1.21.7
+* Update to support 1.21.8
 
 # 2.5.14
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version '1.11-SNAPSHOT'
     id 'maven-publish'
     id "com.modrinth.minotaur" version "2.+"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,16 +6,16 @@ mod_version=2.5.15
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomLib
 archives_base_name=blossom-lib
-supported_versions=1.21.5;1.21.6;1.21.7
+supported_versions=1.21.5;1.21.6;1.21.7;1.21.8
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.7
-yarn_mappings=build.7
+minecraft_version=1.21.8
+yarn_mappings=build.1
 loader_version=0.16.14
 
 # Dependencies
-fabric_version=0.129.0
+fabric_version=0.130.0
 fpa_version=0.3.2
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
 server_translations_version=2.5.1+1.21.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version=2.5.14
+mod_version=2.5.15
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomLib
 archives_base_name=blossom-lib
-supported_versions=1.21.5;1.21.6
+supported_versions=1.21.5;1.21.6;1.21.7
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.6
-yarn_mappings=build.1
+minecraft_version=1.21.7
+yarn_mappings=build.7
 loader_version=0.16.14
 
 # Dependencies
-fabric_version=0.127.1
+fabric_version=0.129.0
 fpa_version=0.3.2
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
 server_translations_version=2.5.1+1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I bumped BlossomLib/BlossomHomes to 1.21.8, here's the PR hoping it can save you some time.
The change required upgrading the gradle wrapper version.


### Tests
(note that I only tested in the scope of BlossomHomes, its not a thorough test of all BlossomLib capabilities)

Minecraft 1.21.5
 - fabric 0.16.14 and fabric 0.17.2
 - fabric-api mod 0.128.2+1.21.5


Minecraft 1.21.8
 - fabric 0.17.2
 - fabric-api mod 0.133.0+1.21.8
 - (I also had a bunch of other mods running as this is my usual instance)
 
 **I didn't test Minecraft versions 1.21.6 or 1.21.7.**