### PR TITLE
Update to Minecraft 1.21.9 (v2.5.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.15
+
+* Update to support 1.21.7
+
 # 2.5.14
 
 * Update to support 1.21.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.5.15
 
-* Update to support 1.21.7
+* Update to support 1.21.8
 
 # 2.5.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
+# 2.5.16
+
+* Update to support Minecraft 1.21.9
+* Fix compilation errors for Minecraft 1.21.9 with updated Yarn mappings
+* Update entity.getWorld() → entity.getEntityWorld() in Permissions.java
+* Update ServerPlayerEntity API method calls to work with new Yarn mappings
+* Update position retrieval to use getX(), getY(), getZ() methods
+* Update Fabric API (0.134.0) and Loader (0.17.2) versions for 1.21.9
+* Clean up supported versions to focus on 1.21.8 and 1.21.9
+
 # 2.5.15
 
-* Update to support 1.21.8
+* Update to support 1.21.9
+* Fix compilation errors for Minecraft 1.21.9 with updated Yarn mappings
 
 # 2.5.14
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version '1.11-SNAPSHOT'
     id 'maven-publish'
     id "com.modrinth.minotaur" version "2.+"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version=2.5.15
+mod_version=2.5.16
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomLib
 archives_base_name=blossom-lib
-supported_versions=1.21.5;1.21.6;1.21.7;1.21.8
+supported_versions=1.21.8;1.21.9
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.8
+minecraft_version=1.21.9
 yarn_mappings=build.1
-loader_version=0.16.14
+loader_version=0.17.2
 
 # Dependencies
-fabric_version=0.130.0
+fabric_version=0.134.0
 fpa_version=0.3.2
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
-server_translations_version=2.5.1+1.21.5
+server_translations_version=2.5.2+1.21.9-pre3

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,16 +6,16 @@ mod_version=2.5.15
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomLib
 archives_base_name=blossom-lib
-supported_versions=1.21.5;1.21.6;1.21.7
+supported_versions=1.21.5;1.21.6;1.21.7;1.21.8
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.7
-yarn_mappings=build.7
+minecraft_version=1.21.8
+yarn_mappings=build.1
 loader_version=0.16.14
 
 # Dependencies
-fabric_version=0.129.0
+fabric_version=0.130.0
 fpa_version=0.3.2
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
 server_translations_version=2.5.1+1.21.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version=2.5.14
+mod_version=2.5.15
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomLib
 archives_base_name=blossom-lib
-supported_versions=1.21.5;1.21.6
+supported_versions=1.21.5;1.21.6;1.21.7
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.6
-yarn_mappings=build.1
+minecraft_version=1.21.7
+yarn_mappings=build.7
 loader_version=0.16.14
 
 # Dependencies
-fabric_version=0.127.1
+fabric_version=0.129.0
 fpa_version=0.3.2
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
 server_translations_version=2.5.1+1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/codedsakura/blossom/lib/permissions/Permissions.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/permissions/Permissions.java
@@ -82,7 +82,7 @@ public class Permissions {
         if (isFPAPILoaded()) {
             return PermissionsExecutor.check(entity, permission, level);
         }
-        World world = entity.getWorld();
+        World world = entity.getEntityWorld();
         return entity.getCommandSource(world instanceof ServerWorld ? (ServerWorld)world : null).hasPermissionLevel(level);
     }
 }

--- a/src/main/java/dev/codedsakura/blossom/lib/teleport/TeleportUtils.java
+++ b/src/main/java/dev/codedsakura/blossom/lib/teleport/TeleportUtils.java
@@ -39,9 +39,9 @@ public class TeleportUtils {
 
     public static void genericCountdown(@Nullable TeleportConfig customConfig, double standStillTime, ServerPlayerEntity who, Runnable onDone) {
         LOGGER.debug("Create new genericCountdown for {} ({} s)", who.getUuid(), standStillTime);
-        MinecraftServer server = who.getServer();
+        MinecraftServer server = who.getEntityWorld().getServer();
         assert server != null;
-        final Vec3d[] lastPos = {who.getPos()};
+        final Vec3d[] lastPos = {new Vec3d(who.getX(), who.getY(), who.getZ())};
 
         final TeleportConfig config = customConfig == null ? BlossomGlobals.CONFIG.baseTeleportation : customConfig.cloneMerge();
 
@@ -122,7 +122,7 @@ public class TeleportUtils {
                     return true;
                 }
 
-                Vec3d pos = who.getPos();
+                Vec3d pos = new Vec3d(who.getX(), who.getY(), who.getZ());
                 double dist = lastPos[0].distanceTo(pos);
                 if (dist < .05) {
                     if (dist != 0) lastPos[0] = pos;
@@ -326,7 +326,7 @@ public class TeleportUtils {
         }
 
         public TeleportDestination(PlayerEntity player) {
-            this((ServerWorld) player.getWorld(), player.getPos(), player.getYaw(), player.getPitch());
+            this((ServerWorld) player.getEntityWorld(), new Vec3d(player.getX(), player.getY(), player.getZ()), player.getYaw(), player.getPitch());
         }
 
         public TeleportDestination(ServerWorld world, double x, double y, double z, float yaw, float pitch) {


### PR DESCRIPTION
Updates BlossomLib to support Minecraft 1.21.9:

- Fix API method calls for updated Yarn mappings
- Update Fabric API and loader versions  

**Testing:** Verified working with BlossomHomes mod only.

Fixes compilation errors and ensures compatibility with MC 1.21.9.